### PR TITLE
pkp/textEditorExtras#20 PHP8 problem when initial arrays are unset

### DIFF
--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -34,64 +34,64 @@
 		<tbody>
 			<tr>
 				<th scope="row">{translate key="manager.setup.contextSummary"}</th>
-				<td><input type="checkbox" name="additions[masthead][description][]" value="image" {if in_array('image', $additions.masthead.description)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[masthead][description][]" value="code" {if in_array('code', $additions.masthead.description)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[masthead][description][]" value="table" {if in_array('table', $additions.masthead.description)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[masthead][description][]" value="image" {if is_array($additions.masthead.description) && in_array('image', $additions.masthead.description)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[masthead][description][]" value="code" {if is_array($additions.masthead.description) && in_array('code', $additions.masthead.description)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[masthead][description][]" value="table" {if is_array($additions.masthead.description) && in_array('table', $additions.masthead.description)}checked="checked"{/if}></td>
 			</tr>
 			<tr>
 				<th scope="row">{translate key="manager.setup.authorGuidelines"}</th>
-				<td><input type="checkbox" name="additions[authorGuidelines][authorGuidelines][]" value="image" {if in_array('image', $additions.authorGuidelines.authorGuidelines)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[authorGuidelines][authorGuidelines][]" value="code" {if in_array('code', $additions.authorGuidelines.authorGuidelines)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[authorGuidelines][authorGuidelines][]" value="table" {if in_array('table', $additions.authorGuidelines.authorGuidelines)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[authorGuidelines][authorGuidelines][]" value="image" {if is_array($additions.authorGuidelines.authorGuidelines) && in_array('image', $additions.authorGuidelines.authorGuidelines)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[authorGuidelines][authorGuidelines][]" value="code" {if is_array($additions.authorGuidelines.authorGuidelines) && in_array('code', $additions.authorGuidelines.authorGuidelines)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[authorGuidelines][authorGuidelines][]" value="table" {if is_array($additions.authorGuidelines.authorGuidelines) && in_array('table', $additions.authorGuidelines.authorGuidelines)}checked="checked"{/if}></td>
 			</tr>
 			<tr>
 				<th scope="row">{translate key="manager.setup.copyrightNotice"}</th>
-				<td><input type="checkbox" name="additions[authorGuidelines][copyrightNotice][]" value="image" {if in_array('image', $additions.authorGuidelines.copyrightNotice)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[authorGuidelines][copyrightNotice][]" value="code" {if in_array('code', $additions.authorGuidelines.copyrightNotice)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[authorGuidelines][copyrightNotice][]" value="table" {if in_array('table', $additions.authorGuidelines.copyrightNotice)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[authorGuidelines][copyrightNotice][]" value="image" {if is_array($additions.authorGuidelines.copyrightNotice) && in_array('image', $additions.authorGuidelines.copyrightNotice)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[authorGuidelines][copyrightNotice][]" value="code" {if is_array($additions.authorGuidelines.copyrightNotice) && in_array('code', $additions.authorGuidelines.copyrightNotice)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[authorGuidelines][copyrightNotice][]" value="table" {if is_array($additions.authorGuidelines.copyrightNotice) && in_array('table', $additions.authorGuidelines.copyrightNotice)}checked="checked"{/if}></td>
 			</tr>
 			<tr>
 				<th scope="row">{translate key="manager.distribution.licenseTerms"}</th>
-				<td><input type="checkbox" name="additions[license][licenseTerms][]" value="image" {if in_array('image', $additions.license.licenseTerms)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[license][licenseTerms][]" value="code" {if in_array('code', $additions.license.licenseTerms)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[license][licenseTerms][]" value="table" {if in_array('table', $additions.license.licenseTerms)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[license][licenseTerms][]" value="image" {if is_array($additions.license.licenseTerms) && in_array('image', $additions.license.licenseTerms)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[license][licenseTerms][]" value="code" {if is_array($additions.license.licenseTerms) && in_array('code', $additions.license.licenseTerms)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[license][licenseTerms][]" value="table" {if is_array($additions.license.licenseTerms) && in_array('table', $additions.license.licenseTerms)}checked="checked"{/if}></td>
 			</tr>
 			<tr>
 				<th scope="row">{translate key="manager.setup.reviewGuidelines"}</th>
-				<td><input type="checkbox" name="additions[reviewerGuidance][reviewGuidelines][]" value="image" {if in_array('image', $additions.reviewerGuidance.reviewGuidelines)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[reviewerGuidance][reviewGuidelines][]" value="code" {if in_array('code', $additions.reviewerGuidance.reviewGuidelines)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[reviewerGuidance][reviewGuidelines][]" value="table" {if in_array('table', $additions.reviewerGuidance.reviewGuidelines)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[reviewerGuidance][reviewGuidelines][]" value="image" {if is_array($additions.reviewerGuidance.reviewGuidelines) && in_array('image', $additions.reviewerGuidance.reviewGuidelines)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[reviewerGuidance][reviewGuidelines][]" value="code" {if is_array($additions.reviewerGuidance.reviewGuidelines) && in_array('code', $additions.reviewerGuidance.reviewGuidelines)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[reviewerGuidance][reviewGuidelines][]" value="table" {if is_array($additions.reviewerGuidance.reviewGuidelines) && in_array('table', $additions.reviewerGuidance.reviewGuidelines)}checked="checked"{/if}></td>
 			</tr>
 			<tr>
 				<th scope="row">{translate key="manager.setup.competingInterests"}</th>
-				<td><input type="checkbox" name="additions[reviewerGuidance][competingInterests][]" value="image" {if in_array('image', $additions.reviewerGuidance.competingInterests)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[reviewerGuidance][competingInterests][]" value="code" {if in_array('code', $additions.reviewerGuidance.competingInterests)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[reviewerGuidance][competingInterests][]" value="table" {if in_array('table', $additions.reviewerGuidance.competingInterests)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[reviewerGuidance][competingInterests][]" value="image" {if is_array($additions.reviewerGuidance.competingInterests) && in_array('image', $additions.reviewerGuidance.competingInterests)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[reviewerGuidance][competingInterests][]" value="code" {if is_array($additions.reviewerGuidance.competingInterests) && in_array('code', $additions.reviewerGuidance.competingInterests)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[reviewerGuidance][competingInterests][]" value="table" {if is_array($additions.reviewerGuidance.competingInterests) && in_array('table', $additions.reviewerGuidance.competingInterests)}checked="checked"{/if}></td>
 			</tr>
 			<tr>
 				<th scope="row">{translate key="plugins.generic.textEditorExtras.setting.emailTemplateBody"}</th>
-				<td><input type="checkbox" name="additions[editEmailTemplate][body][]" value="image" {if in_array('image', $additions.editEmailTemplate.body)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[editEmailTemplate][body][]" value="code" {if in_array('code', $additions.editEmailTemplate.body)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[editEmailTemplate][body][]" value="table" {if in_array('table', $additions.editEmailTemplate.body)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[editEmailTemplate][body][]" value="image" {if is_array($additions.editEmailTemplate.body) && in_array('image', $additions.editEmailTemplate.body)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[editEmailTemplate][body][]" value="code" {if is_array($additions.editEmailTemplate.body) && in_array('code', $additions.editEmailTemplate.body)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[editEmailTemplate][body][]" value="table" {if is_array($additions.editEmailTemplate.body) && in_array('table', $additions.editEmailTemplate.body)}checked="checked"{/if}></td>
 			</tr>
 			<tr>
 				<th scope="row">{translate key="common.abstract"}</th>
-				<td><input type="checkbox" name="additions[titleAbstract][abstract][]" value="image" {if in_array('image', $additions.titleAbstract.abstract)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[titleAbstract][abstract][]" value="code" {if in_array('code', $additions.titleAbstract.abstract)}checked="checked"{/if}></td>
-				<td><input type="checkbox" name="additions[titleAbstract][abstract][]" value="table" {if in_array('table', $additions.titleAbstract.abstract)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[titleAbstract][abstract][]" value="image" {if is_array($additions.titleAbstract.abstract) && in_array('image', $additions.titleAbstract.abstract)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[titleAbstract][abstract][]" value="code" {if is_array($additions.titleAbstract.abstract) && in_array('code', $additions.titleAbstract.abstract)}checked="checked"{/if}></td>
+				<td><input type="checkbox" name="additions[titleAbstract][abstract][]" value="table" {if is_array($additions.titleAbstract.abstract) && in_array('table', $additions.titleAbstract.abstract)}checked="checked"{/if}></td>
 			</tr>
 			{if $currentContext->getData('enableAnnouncements')}
 				<tr>
 					<th scope="row">{translate key="announcement.announcements"}</th>
-					<td><input type="checkbox" name="additions[announcement][description][]" value="image" {if in_array('image', $additions.announcement.description)}checked="checked"{/if}></td>
-					<td><input type="checkbox" name="additions[announcement][description][]" value="code" {if in_array('code', $additions.announcement.description)}checked="checked"{/if}></td>
-					<td><input type="checkbox" name="additions[announcement][description][]" value="table" {if in_array('table', $additions.announcement.description)}checked="checked"{/if}></td>
+					<td><input type="checkbox" name="additions[announcement][description][]" value="image" {if is_array($additions.announcement.description) && in_array('image', $additions.announcement.description)}checked="checked"{/if}></td>
+					<td><input type="checkbox" name="additions[announcement][description][]" value="code" {if is_array($additions.announcement.description) && in_array('code', $additions.announcement.description)}checked="checked"{/if}></td>
+					<td><input type="checkbox" name="additions[announcement][description][]" value="table" {if is_array($additions.announcement.description) && in_array('table', $additions.announcement.description)}checked="checked"{/if}></td>
 				</tr>
 				<tr>
 					<th scope="row">{translate key="plugins.generic.textEditorExtras.setting.announcements.descriptionShort"}</th>
-					<td><input type="checkbox" name="additions[announcement][descriptionShort][]" value="image" {if in_array('image', $additions.announcement.descriptionShort)}checked="checked"{/if}></td>
-					<td><input type="checkbox" name="additions[announcement][descriptionShort][]" value="code" {if in_array('code', $additions.announcement.descriptionShort)}checked="checked"{/if}></td>
-					<td><input type="checkbox" name="additions[announcement][descriptionShort][]" value="table" {if in_array('table', $additions.announcement.descriptionShort)}checked="checked"{/if}></td>
+					<td><input type="checkbox" name="additions[announcement][descriptionShort][]" value="image" {if is_array($additions.announcement.descriptionShort) && in_array('image', $additions.announcement.descriptionShort)}checked="checked"{/if}></td>
+					<td><input type="checkbox" name="additions[announcement][descriptionShort][]" value="code" {if is_array($additions.announcement.descriptionShort) && in_array('code', $additions.announcement.descriptionShort)}checked="checked"{/if}></td>
+					<td><input type="checkbox" name="additions[announcement][descriptionShort][]" value="table" {if is_array($additions.announcement.descriptionShort) && in_array('table', $additions.announcement.descriptionShort)}checked="checked"{/if}></td>
 				</tr>
 			{/if}
 		</tbody>


### PR DESCRIPTION
This remedies an issue with the initial settings array is empty, preventing 

`PHP message: PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array,`

errors. I am not quite sure if there's a more elegant way to do this but this corrects the problem.